### PR TITLE
Change default version to 2019.1, update README version link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ None
 
 #### Variables
 
-* `phpstorm_version` [default: `2018.3.3`]: [Version](https://confluence.jetbrains.com/display/PhpStorm/Previous+PhpStorm+Releases) to install
+* `phpstorm_version` [default: `2019.1`]: [Version](https://www.jetbrains.com/phpstorm/download/index.html#section=linux) to install
 * `phpstorm_install_prefix` [default: `/opt`]: Install prefix
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 # defaults file for phpstorm
 ---
-phpstorm_version: 2018.3.3
+phpstorm_version: 2019.1
 phpstorm_install_prefix: /opt


### PR DESCRIPTION
Hello there,

Just a version bump to the latest stable release available, 2019.1.  I also updated the README version link to point to where the latest stable release version number can be found. The existing confluence link only lists previous releases, meaning 2019.1 is not listed there, just the 2018.3.5 as the most recent.